### PR TITLE
chore: keep engines.pnpm as a range, stop Renovate pinning it

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -142,6 +142,11 @@
       "enabled": false
     },
     {
+      "description": "Keep engines fields as ranges, never exact pins. engines declares the supported version range; the exact selectors are packageManager + mise.toml (still pinned by the global rangeStrategy:pin). Without this override, rangeStrategy:pin rewrites engines.pnpm to an exact latest version (e.g. 11.x) that drifts from the actual pinned pnpm 10.x and breaks Renovate's pnpm lockfile update with ERR_PNPM_UNSUPPORTED_ENGINE. 'replace' (unlike 'bump') only rewrites the range when a release falls outside it: pnpm 10.x minor/patch updates leave '>=10 <11' unchanged, and it changes only at a new major (pnpm 11.x) as part of the deliberate major upgrade.",
+      "matchDepTypes": ["engines"],
+      "rangeStrategy": "replace"
+    },
+    {
       "description": "5-day minimum age for production dependencies (supply-chain protection)",
       "matchDepTypes": ["dependencies"],
       "minimumReleaseAge": "5 days"

--- a/studio/package.json
+++ b/studio/package.json
@@ -46,6 +46,6 @@
   "packageManager": "pnpm@10.28.2+sha512.QYcvA3rSL3NI47Heu69+hnz9RI8nJtnPdMCPGVB8MdLI56EVJbmD/rwt9kC1Q43uYCPrsfhO1DzC1lTSvDJiZA==",
   "engines": {
     "node": ">=22.22.3",
-    "pnpm": ">=10.28.2"
+    "pnpm": ">=10 <11"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "engines": {
     "node": ">=22.22.3",
-    "pnpm": ">=10.33.4"
+    "pnpm": ">=10 <11"
   },
   "scripts": {
     "build": "rm -rf ./dist && npx @11ty/eleventy",


### PR DESCRIPTION
## Problem

Renovate's global `rangeStrategy: "pin"` (renovate.json) rewrites `engines.pnpm` from a range to an exact version (the latest, e.g. `11.8.0`). That drifts from the actual pinned pnpm `10.x` in `packageManager` + `mise.toml`, producing the contradictory diff in the open pnpm PR (#10) and breaking Renovate's own lockfile update with `ERR_PNPM_UNSUPPORTED_ENGINE`.

Mirrors the fix applied in withotto.app (#66).

## Fix

- **web/package.json + studio/package.json**: `engines.pnpm` → `">=10 <11"` (bounded to the tested major; explicit comparators). The exact pnpm selection stays in `packageManager` + `mise.toml`.
- **renovate.json**: add a packageRule `matchDepTypes: ["engines"]` + `rangeStrategy: "replace"` so `engines` stays a range. `replace` only rewrites the range when a release falls outside it — pnpm 10.x minor/patch updates leave `>=10 <11` untouched; it moves only at a new major (pnpm 11.x), as part of the deliberate major upgrade.

`packageManager` + `mise.toml` remain exact-pinned by the global pin strategy.

## Effect on PR #10

Once this lands on `main`, Renovate will re-evaluate the pnpm PR: the `engines.pnpm → 11.8.0` change disappears (10.34.3 is within `>=10 <11`), leaving #10 a clean minor `packageManager`/`mise.toml` bump to 10.34.3.

## Validation

- All three files valid JSON.
- `renovate-config-validator`: Config validated successfully.