### PR TITLE
fix(pnpm): approve build scripts via allowBuilds (pnpm 11)

### DIFF
--- a/studio/pnpm-workspace.yaml
+++ b/studio/pnpm-workspace.yaml
@@ -2,6 +2,12 @@
 # Renovate's bare-semver customManager can both parse it. Mirrors web/pnpm-workspace.yaml.
 manage-package-manager-versions: false
 
+# pnpm 11 requires explicit per-package build-script approval (strictDepBuilds is
+# on by default; an unhandled build script fails install with ERR_PNPM_IGNORED_BUILDS).
+# Sanity bundles esbuild and needs its native binary at build time.
+allowBuilds:
+  esbuild: true
+
 # pnpm 11's supply-chain check (trustPolicy) flags these mainstream transitive
 # deps as "trust downgrade" false positives, which fails `pnpm install`. Excluded
 # surgically so the verification stays ON for every other package. Revisit if

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -1,12 +1,20 @@
 # Netlify's build-image wrapper (run-build-functions.sh) parses the packageManager
 # field with a bare-semver regex and rejects Corepack's +sha512.HASH suffix.
-# pnpm v10 auto-rewrites packageManager with that hash on every install unless
+# pnpm auto-rewrites packageManager with that hash on every install unless
 # this setting is false. See web/package.json `packageManager` and renovate.json.
 manage-package-manager-versions: false
 
-onlyBuiltDependencies:
-  - esbuild
-  - netlify-cli
+# pnpm 11 requires explicit per-package build-script approval (strictDepBuilds is
+# on by default; any unhandled build script fails install with ERR_PNPM_IGNORED_BUILDS).
+# Replaces pnpm 10's onlyBuiltDependencies, which v11 ignores. true = run the
+# package's install/build script; core-js only prints a funding notice so it's skipped.
+allowBuilds:
+  '@parcel/watcher': true
+  core-js: false
+  esbuild: true
+  netlify-cli: true
+  sharp: true
+  unix-dgram: true
 
 # pnpm 11's supply-chain check (trustPolicy) flags these mainstream transitive
 # deps (all netlify-cli's, plus chokidar/semver) as "trust downgrade" false


### PR DESCRIPTION
## Problem

After #12 (pnpm 11), Netlify install fails:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @parcel/watcher, core-js, esbuild, netlify-cli, sharp, unix-dgram
```

pnpm 11 enables `strictDepBuilds` **by default**, making an unhandled build script a *fatal* install error (pnpm 10 only warned — which is why local installs passed: a global pnpm config masked it, and Netlify has none). pnpm 11 also **ignores pnpm 10s `onlyBuiltDependencies`** and uses the `allowBuilds` map instead (it scaffolds the map into `pnpm-workspace.yaml` on the error).

## Fix

- **web**: replace `onlyBuiltDependencies` with `allowBuilds` — `@parcel/watcher`, `esbuild`, `netlify-cli`, `sharp`, `unix-dgram` = `true`; `core-js` = `false` (funding notice only).
- **studio**: add `allowBuilds` — `esbuild: true` (bundled by Sanity).

## Verification

Reproduced Netlify exactly via an **isolated config** (`XDG_CONFIG_HOME` empty, so no masking global config), pnpm 11.7.0, node 24:
- Before: `ERR_PNPM_IGNORED_BUILDS`.
- After: frozen install passes **both** workspaces (build scripts run / skipped as configured).
- `web` `netlify:build` (node 24) → green; `studio` `sanity build` → green.